### PR TITLE
More supported cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ components that still use traditional CSS classNames and global CSS. To allow
 for teams to take advantage of CSS Modules, this babel plugin is used to convert
 all global styles into CSS Modules.
 
+Please note this is a work in progress and does not account for all JavaScript
+constructs yet. It is undergoing the “trial-by-fire” support methodology. If we
+detect a currently-unsupported construct we will print a warning to the console
+with a link to report it at our issue tracker. Please include as much code as
+possible to make it easier for us to add support.
+
+
 ## Usage
 
 * `npm install --save babel-plugin-react-cssmoduleify`
@@ -32,6 +39,11 @@ all global styles into CSS Modules.
 * `cssmodule`: path from `process.cwd()` to global CSS file
 
 ## Example
+
+This currently works on only the babel compiled JavaScript and not the original
+ source. Adding support the original source would likely be fairly trivial. The
+ following example demonstrates the modifications on the babel output of a
+ React component.
 
 ### Before
 

--- a/index.js
+++ b/index.js
@@ -334,8 +334,24 @@ export default function ({Plugin, parse, types: t}) {
         ) return;
 
         const {properties} = node.arguments[1];
-        if (!properties) return;
-        node.arguments[1].properties = properties.map(prop => handleProp(prop, node, scope, file));
+        if (properties) {
+          node.arguments[1].properties = properties.map(prop => handleProp(prop, node, scope, file));
+          return;
+        } else {
+          // an ObjectSpreadProperty was used in the source
+          if (
+            node.arguments[1].type === 'CallExpression' &&
+            node.arguments[1].callee.name.indexOf('extends') !== -1
+          ) {
+            node.arguments[1].arguments = node.arguments[1].arguments.map(prop => {
+              if (prop.type === 'ObjectExpression') {
+                prop.properties = prop.properties.map(prop => handleProp(prop, node, scope, file));
+              }
+
+              return prop;
+            });
+          }
+        }
       },
 
       Program: {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Babel plugin to transform traditional classNames to CSS Modules",
   "main": "lib/index.js",
   "scripts": {
-    "prepublish": "babel index.js -o lib/index.js",
+    "build": "babel index.js -o lib/index.js",
+    "prepublish": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "files": [


### PR DESCRIPTION
crawls the scope chain when resolving identifiers, wrapping an ObjectExpression into the appropriate format is idempotent, and we also support ObjectSpread operators from the original source.