### PR TITLE
String concat issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-react-cssmoduleify",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Babel plugin to transform traditional classNames to CSS Modules",
   "main": "lib/index.js",
   "jsnext:main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -78,6 +78,11 @@ export default ({types: t}) => { // eslint-disable-line
       return t.binaryExpression("+", left, right || t.stringLiteral(" "));
     };
     return copy.reduce((expr, v, i) => {
+      // short circuit empty strings. this happens with something like:
+      // {className: "hello " + "world"}
+      if (v === "") {
+        return expr;
+      }
       const cssModule = t.memberExpression(cssmodule, t.stringLiteral(v), true);
       return concat(expr, (i === copy.length - 1) ? cssModule : concat(cssModule));
     }, concat(t.memberExpression(cssmodule, t.stringLiteral(first), true)));

--- a/test/fixtures/compiled/string/actual.js
+++ b/test/fixtures/compiled/string/actual.js
@@ -32,7 +32,7 @@ var _class = (function (_React$Component) {
     value: function render() {
       return _react2.default.createElement(
         "div",
-        { className: "base" },
+        { className: "base " + "world" },
         "Base test."
       );
     }

--- a/test/fixtures/compiled/string/expected.js
+++ b/test/fixtures/compiled/string/expected.js
@@ -54,7 +54,7 @@ var _class = function (_React$Component) {
   _createClass(_class, [{
     key: "render",
     value: function render() {
-      return _react2.default.createElement("div", { className: _cssmodule["base"] }, "Base test.");
+      return _react2.default.createElement("div", { className: _cssmodule["base"] + " " + _cssmodule["world"] }, "Base test.");
     }
   }]);
 

--- a/test/fixtures/createElement/string/actual.js
+++ b/test/fixtures/createElement/string/actual.js
@@ -4,7 +4,7 @@ export default class extends React.Component {
   render() {
     return React.createElement(
       "div",
-      {className: "base"},
+      {className: "base " + "world"},
       "Base test."
     );
   }

--- a/test/fixtures/createElement/string/expected.js
+++ b/test/fixtures/createElement/string/expected.js
@@ -3,7 +3,7 @@ import React from "react";
 
 export default class extends React.Component {
   render() {
-    return React.createElement("div", { className: _cssmodule["base"] }, "Base test.");
+    return React.createElement("div", { className: _cssmodule["base"] + " " + _cssmodule["world"] }, "Base test.");
   }
 };
 

--- a/test/fixtures/jsx/string/actual.js
+++ b/test/fixtures/jsx/string/actual.js
@@ -3,7 +3,7 @@ import React from "react";
 export default class extends React.Component {
   render() {
     return (
-      <div className="base">
+      <div className="base world">
         Base test.
       </div>
     );

--- a/test/fixtures/jsx/string/expected.js
+++ b/test/fixtures/jsx/string/expected.js
@@ -3,7 +3,7 @@ import React from "react";
 
 export default class extends React.Component {
   render() {
-    return <div className={_cssmodule["base"]}>
+    return <div className={_cssmodule["base"] + " " + _cssmodule["world"]}>
       Base test.
     </div>;
   }


### PR DESCRIPTION
Previously:

```
{className: "hello " + "world"}
```

would result in

```
{className: _cssmodule["hello"] + " " + "_cssmodule[""] + _cssmodule["world"]}
```

which would end up in the browser as something like the following (based
on your configuration):

```
{className: "hello1v1r8123 undefinedworld123vc"}
```